### PR TITLE
タスクを選択ボタンを押すとタスク選択画面に遷移した

### DIFF
--- a/Stepippo/Classes/Views/Prog.storyboard
+++ b/Stepippo/Classes/Views/Prog.storyboard
@@ -25,6 +25,9 @@
                                 <state key="normal" title="期間変更">
                                     <color key="titleColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
                                 </state>
+                                <connections>
+                                    <segue destination="lWE-Ri-xHL" kind="presentation" id="nZl-h3-xfM"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="残り〇〇日" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMm-BU-hLq">
                                 <rect key="frame" x="265" y="181" width="112" height="27"/>
@@ -115,6 +118,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lbT-nJ-4ed" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1495.6521739130435" y="36.830357142857139"/>
+        </scene>
+        <!--GoalSetting-->
+        <scene sceneID="h4N-c7-9eQ">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="GoalSettingVC" storyboardName="GoalSetting" id="lWE-Ri-xHL" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GfH-JH-SzM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1974" y="-110"/>
         </scene>
         <!--進捗-->
         <scene sceneID="AUi-eI-kQW">


### PR DESCRIPTION
fixes #124 

(#の後にcloseしたいissueの番号を記述してください)

### Summary(要約)
遷移先を以下にしました。

- GoalSetting.storyboard

- GoalSettingVC

### Other Information(他の情報)

### Tested(テストしたこと)

- ビルドエラーがないこと

- シュミレーターで挙動を確認。問題なく遷移されていること
![スクリーンショット 2019-05-10 11 29 14](https://user-images.githubusercontent.com/45029154/57498982-e337b900-7318-11e9-995d-57ce22e8288b.png)

![fd3064c6c9bf50884375b1fd5f996cf3](https://user-images.githubusercontent.com/45029154/57498393-ab2f7680-7316-11e9-965c-6de413b0771d.gif)

### Must Reviewer(必須レビュアー)
