### PR TITLE
タスク選択画面の詳細レイアウトを設定

### DIFF
--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		8D8FB76C226B65A60063D8EC /* BugIssueVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FB76B226B65A60063D8EC /* BugIssueVC.swift */; };
 		8D8FB76F226B6F100063D8EC /* SubtitleAndIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FB76D226B6F100063D8EC /* SubtitleAndIconCell.swift */; };
 		8D8FB770226B6F100063D8EC /* SubtitleAndIconCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D8FB76E226B6F100063D8EC /* SubtitleAndIconCell.xib */; };
+		E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E97F692285B04700920B74 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -78,6 +79,7 @@
 		8D8FB76B226B65A60063D8EC /* BugIssueVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugIssueVC.swift; sourceTree = "<group>"; };
 		8D8FB76D226B6F100063D8EC /* SubtitleAndIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleAndIconCell.swift; sourceTree = "<group>"; };
 		8D8FB76E226B6F100063D8EC /* SubtitleAndIconCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitleAndIconCell.xib; sourceTree = "<group>"; };
+		E7E97F692285B04700920B74 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 		0B2ED57522579E2B00C98944 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				E7E97F682285B01400920B74 /* Util */,
 				0BD30D5B2257A04600C700C8 /* Models */,
 				0BD30D5A2257A01800C700C8 /* Controllers */,
 				0B2ED57722579E9C00C98944 /* Views */,
@@ -197,6 +200,14 @@
 				0B2ED57622579E5700C98944 /* Resources */,
 			);
 			path = Stepippo;
+			sourceTree = "<group>";
+		};
+		E7E97F682285B01400920B74 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				E7E97F692285B04700920B74 /* UIView+Extension.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -312,6 +323,7 @@
 				8D071CBD225A44FC004A4A69 /* MiscVC.swift in Sources */,
 				6788A26E226A0ED000E9B0D5 /* ListedIPPOVC.swift in Sources */,
 				0B04AA7A227A9D5100E18F0A /* ProgVC.swift in Sources */,
+				E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */,
 				8D0B3A0522625C0900B71A7C /* SelectableCell.swift in Sources */,
 				8D8FB762226A1AA60063D8EC /* GitHubAPIClient.swift in Sources */,
 				8D8FB768226B47CE0063D8EC /* EnhancementIssueVC.swift in Sources */,

--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -99,10 +99,10 @@
 		0B2ED57522579E2B00C98944 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				E7E97F682285B01400920B74 /* Util */,
-				0BD30D5B2257A04600C700C8 /* Models */,
-				0BD30D5A2257A01800C700C8 /* Controllers */,
 				0B2ED57722579E9C00C98944 /* Views */,
+				0BD30D5A2257A01800C700C8 /* Controllers */,
+				0BD30D5B2257A04600C700C8 /* Models */,
+				E7E97F682285B01400920B74 /* Util */,
 			);
 			path = Classes;
 			sourceTree = "<group>";

--- a/Stepippo/Classes/Util/UIView+Extension.swift
+++ b/Stepippo/Classes/Util/UIView+Extension.swift
@@ -1,0 +1,37 @@
+//
+//  UIView+Extension.swift
+//  Stepippo
+//
+//  Created by 中村 洸貴 on 2019/05/10.
+//  Copyright © 2019 Yasasii-kai. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    
+    @IBInspectable var cornerRadius: CGFloat {
+        get {
+            return layer.cornerRadius
+        }
+        set {
+            layer.cornerRadius = newValue
+        }
+    }
+    
+    @IBInspectable var borderColor: UIColor? {
+        get {
+            if let color = layer.borderColor {
+                return UIColor(cgColor: color)
+            }
+            return nil
+        }
+        set {
+            if let color = newValue {
+                layer.borderColor = color.cgColor
+            } else {
+                layer.borderColor = nil
+            }
+        }
+    }
+}

--- a/Stepippo/Classes/Util/UIView+Extension.swift
+++ b/Stepippo/Classes/Util/UIView+Extension.swift
@@ -19,6 +19,15 @@ extension UIView {
         }
     }
     
+    @IBInspectable var borderWidth: CGFloat {
+        get {
+            return layer.borderWidth
+        }
+        set {
+            layer.borderWidth = newValue
+        }
+    }
+    
     @IBInspectable var borderColor: UIColor? {
         get {
             if let color = layer.borderColor {

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -25,13 +25,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="amU-Xd-oCF">
-                                <rect key="frame" x="16" y="138" width="382" height="30"/>
+                                <rect key="frame" x="16" y="138" width="382" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="36" id="YsW-Ss-2jn"/>
+                                </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPd-En-dJE">
-                                <rect key="frame" x="16" y="184" width="165" height="50"/>
+                                <rect key="frame" x="16" y="190" width="165" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="eGJ-yO-Y0X"/>
                                     <constraint firstAttribute="width" constant="165" id="wnJ-zM-eEq"/>
@@ -49,7 +52,7 @@
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
-                                <rect key="frame" x="192" y="184" width="206" height="50"/>
+                                <rect key="frame" x="192" y="190" width="206" height="50"/>
                                 <color key="backgroundColor" red="0.46202266219999999" green="0.83828371759999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="TKh-B3-jrn"/>

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -27,17 +27,16 @@
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="amU-Xd-oCF">
                                 <rect key="frame" x="16" y="138" width="382" height="36"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="36" id="YsW-Ss-2jn"/>
+                                    <constraint firstAttribute="height" constant="36" id="joN-Va-Nv6"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPd-En-dJE">
-                                <rect key="frame" x="16" y="190" width="165" height="50"/>
+                                <rect key="frame" x="16" y="190" width="185.66666666666666" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="eGJ-yO-Y0X"/>
-                                    <constraint firstAttribute="width" constant="165" id="wnJ-zM-eEq"/>
                                 </constraints>
                                 <state key="normal" title="Stock">
                                     <color key="titleColor" red="0.0" green="0.58980089430000004" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -49,10 +48,13 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                         <real key="value" value="10"/>
                                     </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
-                                <rect key="frame" x="192" y="190" width="206" height="50"/>
+                                <rect key="frame" x="212.66666666666663" y="190" width="185.33333333333337" height="50"/>
                                 <color key="backgroundColor" red="0.46202266219999999" green="0.83828371759999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="TKh-B3-jrn"/>
@@ -76,6 +78,7 @@
                             <constraint firstItem="ysR-pk-NQp" firstAttribute="height" secondItem="qPd-En-dJE" secondAttribute="height" id="7hZ-Qr-m43"/>
                             <constraint firstItem="sbg-v5-gfB" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="8Wc-Mh-h5b"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="amU-Xd-oCF" secondAttribute="trailing" constant="16" id="9nI-Zw-gQq"/>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="width" secondItem="qPd-En-dJE" secondAttribute="width" id="Cth-jJ-LFr"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="GsP-35-cFv"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="JDP-iy-GNa"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="sbg-v5-gfB" secondAttribute="trailing" constant="16" id="Jfr-RC-GRB"/>

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="K0Z-pI-pC9">
-    <device id="retina5_9" orientation="portrait">
+    <device id="retina6_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,40 +15,75 @@
             <objects>
                 <viewController id="lf1-yo-U4p" customClass="GoalSettingVC" customModule="Stepippo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="DeG-pb-48B">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="IPPOを入力して追加しよう" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sbg-v5-gfB">
-                                <rect key="frame" x="16" y="103" width="187" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IPPOを入力して追加しよう" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sbg-v5-gfB">
+                                <rect key="frame" x="16" y="104" width="187" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="amU-Xd-oCF">
-                                <rect key="frame" x="16" y="137" width="343" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="amU-Xd-oCF">
+                                <rect key="frame" x="16" y="138" width="187" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPd-En-dJE">
-                                <rect key="frame" x="19" y="196" width="165" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPd-En-dJE">
+                                <rect key="frame" x="16" y="184" width="88" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="eGJ-yO-Y0X"/>
+                                    <constraint firstAttribute="width" constant="165" id="wnJ-zM-eEq"/>
+                                </constraints>
                                 <state key="normal" title="Stock">
                                     <color key="titleColor" red="0.0" green="0.58980089430000004" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.0" green="0.58980089430000004" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
-                                <rect key="frame" x="194" y="196" width="165" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
+                                <rect key="frame" x="115" y="184" width="88" height="50"/>
                                 <color key="backgroundColor" red="0.46202266219999999" green="0.83828371759999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="TKh-B3-jrn"/>
+                                </constraints>
                                 <state key="normal" title="Add">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" cocoaTouchSystemColor="darkTextColor"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="leading" secondItem="qPd-En-dJE" secondAttribute="trailing" constant="11" id="4ow-ER-KyP"/>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="height" secondItem="qPd-En-dJE" secondAttribute="height" id="7hZ-Qr-m43"/>
+                            <constraint firstItem="sbg-v5-gfB" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="8Wc-Mh-h5b"/>
+                            <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="amU-Xd-oCF" secondAttribute="trailing" constant="16" id="9nI-Zw-gQq"/>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="width" secondItem="qPd-En-dJE" secondAttribute="width" id="Cth-jJ-LFr"/>
+                            <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="GsP-35-cFv"/>
+                            <constraint firstItem="amU-Xd-oCF" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="JDP-iy-GNa"/>
+                            <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="sbg-v5-gfB" secondAttribute="trailing" constant="16" id="Jfr-RC-GRB"/>
+                            <constraint firstItem="sbg-v5-gfB" firstAttribute="top" secondItem="eLm-Bn-yLj" secondAttribute="top" constant="16" id="KeO-l2-cYa"/>
+                            <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="ysR-pk-NQp" secondAttribute="trailing" constant="16" id="MCy-pY-2pd"/>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="top" secondItem="amU-Xd-oCF" secondAttribute="bottom" constant="16" id="OQY-Fd-OpE"/>
+                            <constraint firstItem="qPd-En-dJE" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="R9h-DD-Yyh"/>
+                            <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="S25-7b-JWu"/>
+                            <constraint firstItem="qPd-En-dJE" firstAttribute="top" secondItem="amU-Xd-oCF" secondAttribute="bottom" constant="16" id="fd7-bO-clZ"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="eLm-Bn-yLj"/>
                     </view>
                     <navigationItem key="navigationItem" title="タスク選択" id="MWP-Av-rac">
@@ -66,7 +101,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="K0Z-pI-pC9" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="j51-RF-Xec">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IPPOを入力して追加しよう" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sbg-v5-gfB">
-                                <rect key="frame" x="16" y="104" width="187" height="18"/>
+                                <rect key="frame" x="16" y="104" width="382" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="amU-Xd-oCF">
-                                <rect key="frame" x="16" y="138" width="187" height="30"/>
+                                <rect key="frame" x="16" y="138" width="382" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPd-En-dJE">
-                                <rect key="frame" x="16" y="184" width="88" height="50"/>
+                                <rect key="frame" x="16" y="184" width="165" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="eGJ-yO-Y0X"/>
                                     <constraint firstAttribute="width" constant="165" id="wnJ-zM-eEq"/>
@@ -49,7 +49,7 @@
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
-                                <rect key="frame" x="115" y="184" width="88" height="50"/>
+                                <rect key="frame" x="192" y="184" width="206" height="50"/>
                                 <color key="backgroundColor" red="0.46202266219999999" green="0.83828371759999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="TKh-B3-jrn"/>
@@ -73,7 +73,6 @@
                             <constraint firstItem="ysR-pk-NQp" firstAttribute="height" secondItem="qPd-En-dJE" secondAttribute="height" id="7hZ-Qr-m43"/>
                             <constraint firstItem="sbg-v5-gfB" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="8Wc-Mh-h5b"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="amU-Xd-oCF" secondAttribute="trailing" constant="16" id="9nI-Zw-gQq"/>
-                            <constraint firstItem="ysR-pk-NQp" firstAttribute="width" secondItem="qPd-En-dJE" secondAttribute="width" id="Cth-jJ-LFr"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="GsP-35-cFv"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="JDP-iy-GNa"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="sbg-v5-gfB" secondAttribute="trailing" constant="16" id="Jfr-RC-GRB"/>

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -75,19 +75,17 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="ysR-pk-NQp" firstAttribute="leading" secondItem="qPd-En-dJE" secondAttribute="trailing" constant="11" id="4ow-ER-KyP"/>
-                            <constraint firstItem="ysR-pk-NQp" firstAttribute="height" secondItem="qPd-En-dJE" secondAttribute="height" id="7hZ-Qr-m43"/>
                             <constraint firstItem="sbg-v5-gfB" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="8Wc-Mh-h5b"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="amU-Xd-oCF" secondAttribute="trailing" constant="16" id="9nI-Zw-gQq"/>
                             <constraint firstItem="ysR-pk-NQp" firstAttribute="width" secondItem="qPd-En-dJE" secondAttribute="width" id="Cth-jJ-LFr"/>
-                            <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="GsP-35-cFv"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="JDP-iy-GNa"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="sbg-v5-gfB" secondAttribute="trailing" constant="16" id="Jfr-RC-GRB"/>
                             <constraint firstItem="sbg-v5-gfB" firstAttribute="top" secondItem="eLm-Bn-yLj" secondAttribute="top" constant="16" id="KeO-l2-cYa"/>
                             <constraint firstItem="eLm-Bn-yLj" firstAttribute="trailing" secondItem="ysR-pk-NQp" secondAttribute="trailing" constant="16" id="MCy-pY-2pd"/>
-                            <constraint firstItem="ysR-pk-NQp" firstAttribute="top" secondItem="amU-Xd-oCF" secondAttribute="bottom" constant="16" id="OQY-Fd-OpE"/>
                             <constraint firstItem="qPd-En-dJE" firstAttribute="leading" secondItem="eLm-Bn-yLj" secondAttribute="leading" constant="16" id="R9h-DD-Yyh"/>
                             <constraint firstItem="amU-Xd-oCF" firstAttribute="top" secondItem="sbg-v5-gfB" secondAttribute="bottom" constant="16" id="S25-7b-JWu"/>
                             <constraint firstItem="qPd-En-dJE" firstAttribute="top" secondItem="amU-Xd-oCF" secondAttribute="bottom" constant="16" id="fd7-bO-clZ"/>
+                            <constraint firstItem="ysR-pk-NQp" firstAttribute="baseline" secondItem="qPd-En-dJE" secondAttribute="baseline" id="xLG-fS-Fx4"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="eLm-Bn-yLj"/>
                     </view>


### PR DESCRIPTION
fixes #122 

# 概要
- [x] CornerRadiusとBorderColorをStoryboardで設定できる様に実装
- [x] StockButtonとAddButtonに上記２点を設定
- [x] AutoLayoutの設定

# スクリーンショット
- iPhoneXR
![Simulator Screen Shot - iPhone Xʀ - 2019-05-11 at 00 22 52](https://user-images.githubusercontent.com/40520484/57538257-fd0de600-7382-11e9-99cd-3feb3b10b76a.png)
- iPad Pro
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-05-11 at 00 22 44](https://user-images.githubusercontent.com/40520484/57538281-0dbe5c00-7383-11e9-8277-c4415f766a81.png)

# 注意点
なぜかBorderColorが正しく反映されない
別でIssueを立てます。