### PR TITLE
タスク選択画面での画面遷移の実装

### DIFF
--- a/Stepippo/Classes/Controllers/GoalSettingVC.swift
+++ b/Stepippo/Classes/Controllers/GoalSettingVC.swift
@@ -15,6 +15,14 @@ final class GoalSettingVC: UIViewController {
     
     
     // MARK: - IBAction methods
+    @IBAction func stopButton(_ sender: Any) {
+    }
+    
+    @IBAction func stockButton(_ sender: Any) {
+    }
+    
+    @IBAction func addButton(_ sender: Any) {
+    }
     
     // MARK: - Life cycle methods
     override func viewDidLoad() {

--- a/Stepippo/Classes/Controllers/GoalSettingVC.swift
+++ b/Stepippo/Classes/Controllers/GoalSettingVC.swift
@@ -16,6 +16,7 @@ final class GoalSettingVC: UIViewController {
     
     // MARK: - IBAction methods
     @IBAction func stopButton(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
     }
     
     @IBAction func stockButton(_ sender: Any) {

--- a/Stepippo/Classes/Views/GoalSetting.storyboard
+++ b/Stepippo/Classes/Views/GoalSetting.storyboard
@@ -52,6 +52,9 @@
                                         <real key="value" value="1"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="stockButton:" destination="lf1-yo-U4p" eventType="touchUpInside" id="rzf-pv-nBP"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ysR-pk-NQp">
                                 <rect key="frame" x="212.66666666666663" y="190" width="185.33333333333337" height="50"/>
@@ -70,6 +73,9 @@
                                         <color key="value" cocoaTouchSystemColor="darkTextColor"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="addButton:" destination="lf1-yo-U4p" eventType="touchUpInside" id="36K-pU-9GA"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -90,7 +96,11 @@
                         <viewLayoutGuide key="safeArea" id="eLm-Bn-yLj"/>
                     </view>
                     <navigationItem key="navigationItem" title="タスク選択" id="MWP-Av-rac">
-                        <barButtonItem key="rightBarButtonItem" systemItem="stop" id="XbD-qh-2mA"/>
+                        <barButtonItem key="rightBarButtonItem" systemItem="stop" id="XbD-qh-2mA">
+                            <connections>
+                                <action selector="stopButton:" destination="lf1-yo-U4p" id="wdg-op-xYb"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>


### PR DESCRIPTION
fixes #135 

### Summary(要約)
タスク選択画面での画面遷移の実装

- [x] xボタン押下時に前の画面に戻る
- [x] Stockボタン押下時の画面遷移→不要
- [x] Addボタン押下時の画面遷移→不要

### Other Information(他の情報)
※「Stock」「Add」の押下時の挙動が理解できていないため、次回のMTGで確認する