### PR TITLE
タスクを選択ボタンを押すとタスク選択画面に遷移する

### DIFF
--- a/Stepippo/Classes/Views/Prog.storyboard
+++ b/Stepippo/Classes/Views/Prog.storyboard
@@ -90,6 +90,9 @@
                                                         <real key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <segue destination="FLr-3g-vb7" kind="presentation" id="PFr-Yd-DwR"/>
+                                                </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="達成数2/3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FUI-QW-NrS">
                                                 <rect key="frame" x="182.5" y="4" width="73.5" height="28"/>
@@ -186,6 +189,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lbT-nJ-4ed" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1492.5" y="34.859154929577464"/>
+        </scene>
+        <!--GoalSetting-->
+        <scene sceneID="I2T-4W-ftC">
+            <objects>
+                <viewControllerPlaceholder storyboardName="GoalSetting" id="FLr-3g-vb7" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kNf-X5-vOI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2020" y="-121"/>
         </scene>
         <!--進捗-->
         <scene sceneID="AUi-eI-kQW">


### PR DESCRIPTION
fixes #124 

(#の後にcloseしたいissueの番号を記述してください)

### Summary(要約)

- タスクを選択ボタンを押すとタスク選択画面に遷移する

### Other Information(他の情報)


### Tested(テストしたこと)

- ビルドエラーがないこと

- シュミレーターで問題なく「タスク選択画面」へ遷移できていること

[![Image from Gyazo](https://i.gyazo.com/feef7b5ddcd6e392922bbf91563a9ef5.gif)](https://gyazo.com/feef7b5ddcd6e392922bbf91563a9ef5)

![スクリーンショット 2019-05-24 20 53 33](https://user-images.githubusercontent.com/45029154/58325845-0492bc00-7e66-11e9-8580-442f216dea4b.png)

### Must Reviewer(必須レビュアー)
