### PR TITLE
ストックIPPO表示画面を実装

### DIFF
--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		8DD50CF02285E92A00098AA3 /* RealmObjectAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CEF2285E92A00098AA3 /* RealmObjectAccessible.swift */; };
 		8DD50CF52289A33800098AA3 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CF42289A33800098AA3 /* Int+Extension.swift */; };
 		9173A4B222902180007749F0 /* IPPO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9173A4B122902180007749F0 /* IPPO.swift */; };
+		981A34DF22986BF000D21868 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981A34DE22986BF000D21868 /* Date+Extension.swift */; };
 		E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E97F692285B04700920B74 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -87,6 +88,7 @@
 		8DD50CEF2285E92A00098AA3 /* RealmObjectAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmObjectAccessible.swift; sourceTree = "<group>"; };
 		8DD50CF42289A33800098AA3 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		9173A4B122902180007749F0 /* IPPO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPPO.swift; sourceTree = "<group>"; };
+		981A34DE22986BF000D21868 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		E7E97F692285B04700920B74 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -218,6 +220,7 @@
 			children = (
 				8DD50CF42289A33800098AA3 /* Int+Extension.swift */,
 				E7E97F692285B04700920B74 /* UIView+Extension.swift */,
+				981A34DE22986BF000D21868 /* Date+Extension.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 				0B04AA7A227A9D5100E18F0A /* ProgVC.swift in Sources */,
 				8DD50CF52289A33800098AA3 /* Int+Extension.swift in Sources */,
 				E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */,
+				981A34DF22986BF000D21868 /* Date+Extension.swift in Sources */,
 				8D0B3A0522625C0900B71A7C /* SelectableCell.swift in Sources */,
 				8D8FB762226A1AA60063D8EC /* GitHubAPIClient.swift in Sources */,
 				8D8FB768226B47CE0063D8EC /* EnhancementIssueVC.swift in Sources */,

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -1,30 +1,17 @@
-//
-//  StockedIPPOVC.swift
-//  Stepippo
-//
-//  Created by 山本竜也 on 2019/4/19.
-//  Copyright © 2019 Yasasii-kai. All rights reserved.
-//
-
 import UIKit
+import RealmSwift
 
 final class StockedIPPOVC: UIViewController {
 
+    private var stockedIppoList: Results<IPPO>?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        getStockedIppo()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private func getStockedIppo() {
+        guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
+        stockedIppoList = realm.objects(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]))
     }
-    */
-
 }

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -2,7 +2,7 @@ import UIKit
 import RealmSwift
 import XLPagerTabStrip
 
-final class StockedIPPOVC: UIViewController {
+final class StockedIPPOVC: UIViewController, RealmObjectAccessible {
 
     // TODO: リストのセクション分け
     private var stockedIppoList: Results<IPPO>?
@@ -13,8 +13,7 @@ final class StockedIPPOVC: UIViewController {
     }
     
     private func getStockedIppo() {
-        guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
-        stockedIppoList = realm.objects(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]))
+        stockedIppoList = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]))
     }
 }
 

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -1,8 +1,10 @@
 import UIKit
 import RealmSwift
+import XLPagerTabStrip
 
 final class StockedIPPOVC: UIViewController {
 
+    // TODO: リストのセクション分け
     private var stockedIppoList: Results<IPPO>?
     
     override func viewDidLoad() {
@@ -13,5 +15,59 @@ final class StockedIPPOVC: UIViewController {
     private func getStockedIppo() {
         guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
         stockedIppoList = realm.objects(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]))
+    }
+}
+
+extension StockedIPPOVC: IndicatorInfoProvider {
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        return "ストック"
+    }
+}
+
+extension StockedIPPOVC: UITableViewDataSource {
+    // TODO: セクション分けとセクションヘッダーの表示
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return stockedIppoList?.count ?? 0
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return "SECTION HEADING"
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        
+        if let ippo = stockedIppoList?[indexPath.row] {
+            cell.textLabel?.text = ippo.title
+            cell.detailTextLabel?.text = ippo.addDateTime.toFormattedString()
+        }
+        
+        return cell
+    }
+}
+
+extension StockedIPPOVC: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { (_, _, completion) in
+            guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
+            try? realm.write { [weak self] in
+                if let ippo = self?.stockedIppoList?[indexPath.row] {
+                    realm.delete(ippo)
+                    tableView.reloadData()
+                    completion(true)
+                }
+            }
+            completion(false)
+        }
+        let doneAction = UIContextualAction(style: .normal, title: "Done") { (_, _, completion) in
+            guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
+            try? realm.write { [weak self] in
+                self?.stockedIppoList?[indexPath.row]._status = IPPOStatus.achieved.rawValue
+                tableView.reloadData()
+                completion(true)
+            }
+            completion(false)
+        }
+        return UISwipeActionsConfiguration(actions: [deleteAction, doneAction])
     }
 }

--- a/Stepippo/Classes/Util/Date+Extension.swift
+++ b/Stepippo/Classes/Util/Date+Extension.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Date {
+    func toFormattedString(format: String = "yyyy年M月d日 HH:mm") -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = format
+        return formatter.string(from: self)
+    }
+}

--- a/Stepippo/Classes/Views/StockedIPPO.storyboard
+++ b/Stepippo/Classes/Views/StockedIPPO.storyboard
@@ -1,7 +1,71 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="n5z-lw-ZV0">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--StockedIPPOVC-->
+        <scene sceneID="No4-Lc-t45">
+            <objects>
+                <viewController storyboardIdentifier="StockedIPPOVC" useStoryboardIdentifierAsRestorationIdentifier="YES" id="n5z-lw-ZV0" customClass="StockedIPPOVC" customModule="Stepippo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="p3w-QF-SEm">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ftf-g2-0Ez">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="Cell" textLabel="Uuh-ME-39V" detailTextLabel="BIu-Mi-h9S" style="IBUITableViewCellStyleSubtitle" id="tpJ-Hg-252">
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tpJ-Hg-252" id="IzT-5W-a8t">
+                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Uuh-ME-39V">
+                                                    <rect key="frame" x="15" y="5" width="33.5" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BIu-Mi-h9S">
+                                                    <rect key="frame" x="15" y="25.5" width="33" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="n5z-lw-ZV0" id="Ee9-hG-W8L"/>
+                                    <outlet property="delegate" destination="n5z-lw-ZV0" id="CCB-hs-d4r"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="Mnn-Mo-lar" firstAttribute="bottom" secondItem="ftf-g2-0Ez" secondAttribute="bottom" id="Ikx-7d-t5P"/>
+                            <constraint firstItem="ftf-g2-0Ez" firstAttribute="leading" secondItem="Mnn-Mo-lar" secondAttribute="leading" id="XeZ-5X-nmQ"/>
+                            <constraint firstItem="Mnn-Mo-lar" firstAttribute="trailing" secondItem="ftf-g2-0Ez" secondAttribute="trailing" id="Y73-rE-Kml"/>
+                            <constraint firstItem="ftf-g2-0Ez" firstAttribute="top" secondItem="Mnn-Mo-lar" secondAttribute="top" id="deC-3g-HYn"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Mnn-Mo-lar"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hkD-HO-ETW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-264" y="-49"/>
+        </scene>
+    </scenes>
 </document>


### PR DESCRIPTION
fixes #71 

### Summary(要約)
ストック済みIPPOをRealmから取り出して一覧表示する画面を実装

### Other Information(他の情報)
セクション分けの要件を理解できていない（決まっていない？）為、TODOとして別PRにて対応予定
TableViewCellのフルスワイプアクションは一旦tureで実装

### Tested(テストしたこと)
シミュレーターにて動作確認

iPhoneXR | iPhone8 | iPhoneSE | iPad Air2
---|---|---|---
![Simulator Screen Shot - iPhone Xʀ - 2019-05-25 at 23 57 05](https://user-images.githubusercontent.com/50907353/58371203-4dbc3c00-7f4a-11e9-8b77-1f846c02e6af.png)| ![Simulator Screen Shot - iPhone 8 - 2019-05-25 at 23 58 32](https://user-images.githubusercontent.com/50907353/58371214-63316600-7f4a-11e9-82dc-a71336cdde6f.png)| ![Simulator Screen Shot - iPhone SE - 2019-05-25 at 23 59 47](https://user-images.githubusercontent.com/50907353/58371267-d76c0980-7f4a-11e9-86a6-06d071c61d38.png)| ![Simulator Screen Shot - iPad Air 2 - 2019-05-26 at 00 00 29](https://user-images.githubusercontent.com/50907353/58371272-e8b51600-7f4a-11e9-8286-ecb8e34f28a5.png)
---|---|---|---
  ![Simulator Screen Shot - iPhone Xʀ - 2019-05-25 at 23 57 55](https://user-images.githubusercontent.com/50907353/58371204-514fc300-7f4a-11e9-9bd1-177f01074f8e.png)| ![Simulator Screen Shot - iPhone 8 - 2019-05-25 at 23 58 36](https://user-images.githubusercontent.com/50907353/58371286-1732f100-7f4b-11e9-90c6-39b866bfff66.png)| ![Simulator Screen Shot - iPhone SE - 2019-05-25 at 23 59 51](https://user-images.githubusercontent.com/50907353/58371287-1dc16880-7f4b-11e9-83f5-3df9ced6c078.png)| ![Simulator Screen Shot - iPad Air 2 - 2019-05-26 at 00 00 33](https://user-images.githubusercontent.com/50907353/58371288-24e87680-7f4b-11e9-9834-06fa2ed14fb0.png)





