### PR TITLE
タスク一覧画面の実装

### DIFF
--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		6788A274226A0F1400E9B0D5 /* ListedIPPO.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6788A273226A0F1400E9B0D5 /* ListedIPPO.storyboard */; };
 		6788A276226A0F2100E9B0D5 /* AchievedIPPO.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6788A275226A0F2100E9B0D5 /* AchievedIPPO.storyboard */; };
 		6788A278226A0F2B00E9B0D5 /* StockedIPPO.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6788A277226A0F2B00E9B0D5 /* StockedIPPO.storyboard */; };
-		67920DB02262C2D200127083 /* XLPagerTabStrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67920DAF2262C2D100127083 /* XLPagerTabStrip.framework */; };
 		8D071CB7225A4435004A4A69 /* Misc.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D071CB6225A4435004A4A69 /* Misc.storyboard */; };
 		8D071CBA225A44CE004A4A69 /* MiscCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D071CB8225A44CE004A4A69 /* MiscCell.swift */; };
 		8D071CBB225A44CE004A4A69 /* MiscCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D071CB9225A44CE004A4A69 /* MiscCell.xib */; };
@@ -45,6 +44,7 @@
 		8DD50CF52289A33800098AA3 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CF42289A33800098AA3 /* Int+Extension.swift */; };
 		9173A4B222902180007749F0 /* IPPO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9173A4B122902180007749F0 /* IPPO.swift */; };
 		981A34DF22986BF000D21868 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981A34DE22986BF000D21868 /* Date+Extension.swift */; };
+		98505F8B229ED3FA00AE0891 /* XLPagerTabStrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67920DAF2262C2D100127083 /* XLPagerTabStrip.framework */; };
 		E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E97F692285B04700920B74 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -98,7 +98,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D8E2856227B26EB00299B5B /* Realm.framework in Frameworks */,
-				67920DB02262C2D200127083 /* XLPagerTabStrip.framework in Frameworks */,
+				98505F8B229ED3FA00AE0891 /* XLPagerTabStrip.framework in Frameworks */,
 				8D8E2855227B26EB00299B5B /* RealmSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Stepippo/Classes/Controllers/ListedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/ListedIPPOVC.swift
@@ -1,31 +1,27 @@
-
 //
 //  ListedIPPOVC.swift
 //  Stepippo
 //
-//  Created by 山本竜也 on 2019/4/19.
+//  Created by Sab on 2019/5/26.
 //  Copyright © 2019 Yasasii-kai. All rights reserved.
 //
 
 import UIKit
+import XLPagerTabStrip
 
-final class ListedIPPOVC: UIViewController {
+final class ListedIPPOVC: ButtonBarPagerTabStripViewController {
 
     override func viewDidLoad() {
+        settings.style.buttonBarItemBackgroundColor = UIColor(red: 0, green: 0.5, blue: 1, alpha: 1)
+        settings.style.buttonBarItemTitleColor = .white
+        settings.style.selectedBarBackgroundColor = .cyan
+        settings.style.buttonBarMinimumLineSpacing = 0
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+        let stockedIppoVC = UIStoryboard(name: "StockedIPPO", bundle: nil).instantiateInitialViewController() as! StockedIPPOVC
+        let achievedIppoVC = UIStoryboard(name: "AchievedIPPO", bundle: nil).instantiateInitialViewController() as! AchievedIPPOVC
+        return [stockedIppoVC, achievedIppoVC]
     }
-    */
-
 }

--- a/Stepippo/Classes/Views/ListedIPPO.storyboard
+++ b/Stepippo/Classes/Views/ListedIPPO.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4A7-6S-evl">
-                                <rect key="frame" x="0.0" y="132" width="375" height="646"/>
+                                <rect key="frame" x="0.0" y="132" width="375" height="597"/>
                             </scrollView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="O7w-D4-8rd" customClass="ButtonBarView" customModule="XLPagerTabStrip">
                                 <rect key="frame" x="0.0" y="88" width="375" height="44"/>
@@ -34,7 +34,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="H19-Z3-tvg">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="H19-Z3-tvg">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">

--- a/Stepippo/Classes/Views/ListedIPPO.storyboard
+++ b/Stepippo/Classes/Views/ListedIPPO.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5t5-Pc-6pP">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -10,22 +10,62 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--ListedIPPOVC-->
+        <!--タスク一覧-->
         <scene sceneID="anc-aB-rRo">
             <objects>
                 <viewController id="dd7-PH-JGy" customClass="ListedIPPOVC" customModule="Stepippo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qef-z1-zVH">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4A7-6S-evl">
+                                <rect key="frame" x="0.0" y="132" width="375" height="646"/>
+                            </scrollView>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="O7w-D4-8rd" customClass="ButtonBarView" customModule="XLPagerTabStrip">
+                                <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="P3P-EJ-cF2"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="D1D-ls-VdR">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="H19-Z3-tvg">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="3jn-us-kFk" firstAttribute="trailing" secondItem="4A7-6S-evl" secondAttribute="trailing" id="JNo-yR-eba"/>
+                            <constraint firstItem="O7w-D4-8rd" firstAttribute="top" secondItem="3jn-us-kFk" secondAttribute="top" id="T3L-Yb-qam"/>
+                            <constraint firstItem="4A7-6S-evl" firstAttribute="top" secondItem="O7w-D4-8rd" secondAttribute="bottom" id="XLK-NX-DD1"/>
+                            <constraint firstItem="O7w-D4-8rd" firstAttribute="leading" secondItem="3jn-us-kFk" secondAttribute="leading" id="nY5-Sr-iMx"/>
+                            <constraint firstItem="4A7-6S-evl" firstAttribute="bottom" secondItem="3jn-us-kFk" secondAttribute="bottom" id="uTI-9c-hbg"/>
+                            <constraint firstItem="4A7-6S-evl" firstAttribute="leading" secondItem="3jn-us-kFk" secondAttribute="leading" id="w4U-OO-hQK"/>
+                            <constraint firstItem="3jn-us-kFk" firstAttribute="trailing" secondItem="O7w-D4-8rd" secondAttribute="trailing" id="xJW-fW-qwS"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="3jn-us-kFk"/>
                     </view>
-                    <navigationItem key="navigationItem" id="6oM-9x-vhy"/>
-                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationItem key="navigationItem" title="タスク一覧" id="6oM-9x-vhy"/>
+                    <connections>
+                        <outlet property="buttonBarView" destination="O7w-D4-8rd" id="pPF-NZ-IYy"/>
+                        <outlet property="containerView" destination="4A7-6S-evl" id="PEF-ec-qHf"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FJd-k5-cGi" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="544" y="785"/>
+            <point key="canvasLocation" x="543.20000000000005" y="784.72906403940885"/>
         </scene>
         <!--タスク一覧-->
         <scene sceneID="f7V-Vb-8mR">
@@ -35,7 +75,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="6Z1-IX-9yE">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>


### PR DESCRIPTION
fixes #72 

### Summary(要約)
XLPagerTabStripを使い、達成済み・ストックIPPOの画面を切り替えられるタスク一覧画面を作成する

### Other Information(他の情報)
https://github.com/yasasii-team/Stepippo-iOS/pull/159 を取り込まないと動きません。

![Simulator Screen Shot - iPhone SE - 2019-05-30 at 00 12 39](https://user-images.githubusercontent.com/50907353/58568855-fd0d5180-826f-11e9-924c-33ca3afd1c1d.png)

### Tested(テストしたこと)
仮の画面を用意してシミュレータで動作確認
