### PR TITLE
idを主キーに設定する処理を追加

### DIFF
--- a/Stepippo/Classes/Models/IPPO.swift
+++ b/Stepippo/Classes/Models/IPPO.swift
@@ -41,4 +41,9 @@ class IPPO: Object {
             _status = newValue.rawValue
         }
     }
+    
+    // 主キーを設定
+    override static func primaryKey() -> String? {
+        return "id"
+    }
 }


### PR DESCRIPTION
fixes #160 

### Summary(要約)
プロパティidを主キーに設定する処理を追加

### Tested(テストしたこと)
IPPOにプライマリキーとしての"id"が存在すること
RealmObjectAccesible のメソッドを使ってwriteできること

![image](https://user-images.githubusercontent.com/45661924/58485452-0c709a00-819f-11e9-9d6e-121db0c24e1f.png)
