### PR TITLE
ストック済みIPPO画面の表示順設定

### DIFF
--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -13,7 +13,7 @@ final class StockedIPPOVC: UIViewController, RealmObjectAccessible {
     }
     
     private func getStockedIppo() {
-        stockedIppoList = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]))
+        stockedIppoList = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue])).sorted(byKeyPath: "addDateTime", ascending: false)
     }
 }
 
@@ -24,13 +24,8 @@ extension StockedIPPOVC: IndicatorInfoProvider {
 }
 
 extension StockedIPPOVC: UITableViewDataSource {
-    // TODO: セクション分けとセクションヘッダーの表示
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return stockedIppoList?.count ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "SECTION HEADING"
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
fixes #167 

### Summary(要約)
ストック済みIPPOリストを追加日が新しい順で表示する

### Other Information(他の情報)
セクション分けはしないので、セクションヘッダーの表示を削除

### Tested(テストしたこと)
以下のデータを追加してシミュレータで表示

```swift
let a = IPPO()
        a.title = "ippo1"
        a.addDateTime = Date()
        a.status = IPPOStatus.stock
        let b = IPPO()
        b.title = "ippo2"
        b.addDateTime = Date().addingTimeInterval(TimeInterval(exactly: -5000)!)
        b.status = IPPOStatus.stock
        let c = IPPO()
        c.title = "ippo3"
        c.addDateTime = Date().addingTimeInterval(TimeInterval(exactly: -10000)!)
        c.status = IPPOStatus.stock
        write(a)
        write(b)
        write(c)
```

![Simulator Screen Shot - iPhone Xʀ - 2019-06-02 at 23 47 04](https://user-images.githubusercontent.com/50907353/58763038-26d8b800-8591-11e9-895f-f8127cfa8a2c.png)
