### PR TITLE
曜日を記憶するUserDefaultsの型をIntに変更

### DIFF
--- a/Stepippo/Classes/Controllers/MiscVC.swift
+++ b/Stepippo/Classes/Controllers/MiscVC.swift
@@ -137,8 +137,14 @@ extension MiscVC: UITableViewDataSource {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "miscCell", for: indexPath) as! MiscCell
                 cell.iconImage.image = #imageLiteral(resourceName: "DayOfWeekToStart")
                 cell.titleLabel.text = "週の開始曜日"
-                // UserDefaultsに記憶している設定を使用
-                cell.detailLabel.text = userDefault.string(forKey: "dayOfWeekToStart") ?? "月曜日"
+                // UserDefaultsで記憶している曜日情報を取得
+                let weekdayIndex = userDefault.integer(forKey: "dayOfWeekToStart")
+                // 曜日表示用フォーマットを設定
+                let formatter = DateFormatter()
+                formatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "EEEE", options: 0, locale: Locale.autoupdatingCurrent)
+                // 曜日を配列から取得
+                let weekday = formatter.weekdaySymbols[weekdayIndex]
+                cell.detailLabel.text = weekday
                 return cell
 
             case .dateToStart:
@@ -234,13 +240,14 @@ extension MiscVC: UITableViewDelegate {
                 let alert = UIAlertController(title: "何曜日からスタートしますか？",
                                               message: "期限を1週間とした時の基準となる曜日を選択してください",
                                               preferredStyle: .actionSheet)
-                
-                let weeks = ["月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日", "日曜日"]
-                
-                for week in weeks {
+                // 曜日を取得するためのフォーマット
+                let df = DateFormatter()
+                df.dateFormat = DateFormatter.dateFormat(fromTemplate: "EEEE", options: 0, locale: Locale.autoupdatingCurrent)
+                // 曜日を配列から取得
+                for (index, week) in df.weekdaySymbols.enumerated() {
                     alert.addAction(UIAlertAction(title: week, style: .default) { [weak self] _ in
                         // 選択した曜日を記憶
-                        self?.userDefault.set(week, forKey: "dayOfWeekToStart")
+                        self?.userDefault.set(index, forKey: "dayOfWeekToStart")
                         cell.detailLabel.text = week
                         cell.detailLabel.isHidden = false
                     })


### PR DESCRIPTION
fixes #187

### Summary(要約)
今までは日本語文字列を保存していましたが、数値で保存するように変更
1〜7か0〜6どちらで保存するかで迷いましたが、少ない表記ですむ0~6を採用

0: 日曜日
1: 月曜日
...

現状、曜日が英語で表示されますが、
`Locale.autoupdatingCurrent` を使用しているので、
ローカライズに日本語を追加すれば、日本語表記になるはず…

### Other Information(他の情報)
ArchievedIPPO.swiftにも影響あり

### Tested(テストしたこと)
選択した曜日が記憶でき、表示できること