### PR TITLE
残り期間をLabelに表示する

### DIFF
--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -64,12 +64,11 @@ final class ProgVC: UIViewController {
         // 選択した期間を「deadlineCycle」という名前(key)でUserDefaultsに保存する
         userDefaults.set(sender.title, forKey: "deadlineCycle")
     }
-
+    
     
     func calcRemainingPeriod() -> String {
         // 現在時刻を取得
         let today = Date()
-        print("現在日時: \(today)")
         // UserDefaultsのインスタンス
         let userDefaults = UserDefaults.standard
         // カレンダーのインスタンス
@@ -84,25 +83,22 @@ final class ProgVC: UIViewController {
             let endday = calendar.date(bySetting: .hour, value: timeOfDayToStart, of: today)
             // // 上記で算出した時間と現時刻の差分を取得する
             let remaining = calendar.dateComponents([.hour, .minute], from: today, to: endday!)
-            print("期日まで残り\(remaining.hour!)時間と\(remaining.minute!)分")
             
             // TODO: 毎日の場合の計算
-            return "期日まで残り\(remaining.hour!)時間と\(remaining.minute!)分"
+            return "残り\(remaining.hour!)時間\(remaining.minute!)分"
             
         case "毎週":
             // UserDefaultsで保存してある曜日設定を取得
             let dayOfWeekToStart = userDefaults.integer(forKey: "dayOfWeekToStart") + 1
             // 期日を計算
             let nextPeriod = calendar.date(bySetting: .weekday, value: dayOfWeekToStart, of: today)
-            print("期日: ", nextPeriod ?? "nil")
             // 残り日数を計算
             let remaining = calendar.dateComponents([.day, .hour], from: today, to: nextPeriod!)
-            print("期日まで残り\(remaining.day!)日と\(remaining.hour!)時間")
             //残り0日のときに時間のみを出力する
             if remaining.day! == 0 {
                 return "残り\(remaining.hour!)時間"
             }
-                return "残り\(remaining.day!)日と\(remaining.hour!)時間"
+            return "残り\(remaining.day!)日\(remaining.hour!)時間"
             
         case "毎月":
             // UserDefaultsで保存してある曜日設定を取得
@@ -115,8 +111,6 @@ final class ProgVC: UIViewController {
             let deadline = calendar.nextDate(after: today, matching: components, matchingPolicy: .nextTime)
             // 上記で算出した日付と今日の日付の差分を取得する
             let remaining = calendar.dateComponents([.day, .hour], from: today, to: deadline!)
-            print("期日まで残り\(remaining.day!)日と\(remaining.hour!)時間")
-            
             // TODO: 毎月の場合の計算
             return "残り\(remaining.day!)日"
             
@@ -126,15 +120,16 @@ final class ProgVC: UIViewController {
         }
     }
     
+    @IBOutlet weak var cycleLabel: UILabel!
     override func viewDidLoad() {
         super.viewDidLoad()
         // UserDefaults のインスタンス
         let userDefaults = UserDefaults.standard
         // UserDefaultsに今保存した値を確認する
-        let nowDeadlineCycle = userDefaults.string(forKey: "deadlineCycle") ?? "deadlineCycleは保存されていません"
-        print("期間設定: \(nowDeadlineCycle)")
+        _ = userDefaults.string(forKey: "deadlineCycle") ?? "deadlineCycleは保存されていません"
+
         let result = calcRemainingPeriod()
-        print(result)
         
+        cycleLabel.text = result
     }
 }

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -64,6 +64,59 @@ final class ProgVC: UIViewController {
         // 選択した期間を「deadlineCycle」という名前(key)でUserDefaultsに保存する
         userDefaults.set(sender.title, forKey: "deadlineCycle")
     }
+
+    
+    func calcRemainingPeriod() -> String {
+        // 現在時刻を取得
+        let today = Date()
+        print("現在日時: \(today)")
+        // UserDefaultsのインスタンス
+        let userDefaults = UserDefaults.standard
+        // カレンダーのインスタンス
+        let calendar = Calendar.current
+        // 条件として、UserDefaultsに保存した期日サイクルを取得して使う
+        switch userDefaults.string(forKey: "deadlineCycle") {
+            
+        case "毎日":
+            let timeOfDayToStart = userDefaults.integer(forKey: "timeOfDayToStart") + 1
+            // 期日を計算
+            let nextPeriod = calendar.date(bySetting: .minute, value: timeOfDayToStart, of: today)
+            // 残り時間を計算
+            let remaining = calendar.dateComponents([.minute], from: today, to: nextPeriod!)
+            print("期日まで残り\(remaining.minute!)分")
+            
+            // TODO: 毎日の場合の計算
+            return "期日まで残り\(remaining.minute!)分"
+            
+        case "毎週":
+            // UserDefaultsで保存してある曜日設定を取得
+            let dayOfWeekToStart = userDefaults.integer(forKey: "dayOfWeekToStart") + 1
+            // 期日を計算
+            let nextPeriod = calendar.date(bySetting: .weekday, value: dayOfWeekToStart, of: today)
+            print("期日: ", nextPeriod ?? "nil")
+            // 残り日数を計算
+            let remaining = calendar.dateComponents([.day, .hour], from: today, to: nextPeriod!)
+            print("期日まで残り\(remaining.day!)日と\(remaining.hour!)時間")
+            
+            return "残り\(remaining.day!)日と\(remaining.hour!)時間"
+            
+        case "毎月":
+            // UserDefaultsで保存してある曜日設定を取得
+            let dayOfMonthToStart = userDefaults.integer(forKey: "dayOfMonthToStart") + 1
+            // 期日を計算
+            let nextPeriod = calendar.date(bySetting: .day, value: dayOfMonthToStart, of: today)
+            // 残り日数を計算
+            let remaining = calendar.dateComponents([.day], from: today, to: nextPeriod!)
+            print("期日まで残り\(remaining.day!)日")
+            
+            // TODO: 毎月の場合の計算
+            return "残り\(remaining.day!)日"
+            
+        default:
+            // TODO: 定数化してdefaultsを使わない実装にする
+            return "TODO: default"
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,5 +125,8 @@ final class ProgVC: UIViewController {
         // UserDefaultsに今保存した値を確認する
         let nowDeadlineCycle = userDefaults.string(forKey: "deadlineCycle") ?? "deadlineCycleは保存されていません"
         print("期間設定: \(nowDeadlineCycle)")
+        let result = calcRemainingPeriod()
+        print(result)
+        
     }
 }

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -78,11 +78,12 @@ final class ProgVC: UIViewController {
         switch userDefaults.string(forKey: "deadlineCycle") {
             
         case "毎日":
+            // UserDefaultsで保存してある曜日設定を取得
             let timeOfDayToStart = userDefaults.integer(forKey: "timeOfDayToStart")
-            // 期日を計算
-            let nextPeriod = calendar.date(bySetting: .minute, value: timeOfDayToStart, of: today)
-            // 残り時間を計算
-            let remaining = calendar.dateComponents([.hour, .minute], from: today, to: nextPeriod!)
+            // 時間を計算
+            let endday = calendar.date(bySetting: .hour, value: timeOfDayToStart, of: today)
+            // // 上記で算出した時間と現時刻の差分を取得する
+            let remaining = calendar.dateComponents([.hour, .minute], from: today, to: endday!)
             print("期日まで残り\(remaining.hour!)時間と\(remaining.minute!)分")
             
             // TODO: 毎日の場合の計算

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -78,15 +78,15 @@ final class ProgVC: UIViewController {
         switch userDefaults.string(forKey: "deadlineCycle") {
             
         case "毎日":
-            let timeOfDayToStart = userDefaults.integer(forKey: "timeOfDayToStart") + 1
+            let timeOfDayToStart = userDefaults.integer(forKey: "timeOfDayToStart")
             // 期日を計算
             let nextPeriod = calendar.date(bySetting: .minute, value: timeOfDayToStart, of: today)
             // 残り時間を計算
-            let remaining = calendar.dateComponents([.minute], from: today, to: nextPeriod!)
-            print("期日まで残り\(remaining.minute!)分")
+            let remaining = calendar.dateComponents([.hour, .minute], from: today, to: nextPeriod!)
+            print("期日まで残り\(remaining.hour!)時間と\(remaining.minute!)分")
             
             // TODO: 毎日の場合の計算
-            return "期日まで残り\(remaining.minute!)分"
+            return "期日まで残り\(remaining.hour!)時間と\(remaining.minute!)分"
             
         case "毎週":
             // UserDefaultsで保存してある曜日設定を取得
@@ -102,7 +102,7 @@ final class ProgVC: UIViewController {
             
         case "毎月":
             // UserDefaultsで保存してある曜日設定を取得
-            let dayOfMonthToStart = userDefaults.integer(forKey: "dayOfMonthToStart") + 1
+            let dayOfMonthToStart = userDefaults.integer(forKey: "dayOfMonthToStart")
             // 期日を計算
             let nextPeriod = calendar.date(bySetting: .day, value: dayOfMonthToStart, of: today)
             // 残り日数を計算

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -11,15 +11,15 @@ import UIKit
 final class ProgVC: UIViewController {
     
     @IBAction private func checkClicked1(_ sender: CheckButton) {
-         animate(button: sender)
+        animate(button: sender)
     }
     
     @IBAction func checkClicked2(_ sender: CheckButton) {
-         animate(button: sender)
+        animate(button: sender)
     }
     
     @IBAction func checkClicked3(_ sender: CheckButton) {
-         animate(button: sender)
+        animate(button: sender)
     }
     
     private func animate(button: UIButton) {
@@ -102,12 +102,16 @@ final class ProgVC: UIViewController {
             
         case "毎月":
             // UserDefaultsで保存してある曜日設定を取得
+            // 設定されていない場合の初期値は31日（月末）とする
+            userDefaults.register(defaults: ["dayOfMonthToStart": 1])
             let dayOfMonthToStart = userDefaults.integer(forKey: "dayOfMonthToStart")
-            // 期日を計算
-            let nextPeriod = calendar.date(bySetting: .day, value: dayOfMonthToStart, of: today)
-            // 残り日数を計算
-            let remaining = calendar.dateComponents([.day], from: today, to: nextPeriod!)
-            print("期日まで残り\(remaining.day!)日")
+            // 取得した日付情報(Int)でDateComponentsを生成する
+            let components = DateComponents(day: dayOfMonthToStart)
+            // 次の「指定された日付」に当てはまる日付情報を取得する（例: 31日なら今月末の日付）
+            let deadline = calendar.nextDate(after: today, matching: components, matchingPolicy: .nextTime)
+            // 上記で算出した日付と今日の日付の差分を取得する
+            let remaining = calendar.dateComponents([.day, .hour], from: today, to: deadline!)
+            print("期日まで残り\(remaining.day!)日と\(remaining.hour!)時間")
             
             // TODO: 毎月の場合の計算
             return "残り\(remaining.day!)日"

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -98,8 +98,11 @@ final class ProgVC: UIViewController {
             // 残り日数を計算
             let remaining = calendar.dateComponents([.day, .hour], from: today, to: nextPeriod!)
             print("期日まで残り\(remaining.day!)日と\(remaining.hour!)時間")
-            
-            return "残り\(remaining.day!)日と\(remaining.hour!)時間"
+            //残り0日のときに時間のみを出力する
+            if remaining.day! == 0 {
+                return "残り\(remaining.hour!)時間"
+            }
+                return "残り\(remaining.day!)日と\(remaining.hour!)時間"
             
         case "毎月":
             // UserDefaultsで保存してある曜日設定を取得

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -10,6 +10,8 @@ import UIKit
 
 final class ProgVC: UIViewController {
     
+    @IBOutlet weak var cycleLabel: UILabel!
+    
     @IBAction private func checkClicked1(_ sender: CheckButton) {
         animate(button: sender)
     }
@@ -84,7 +86,6 @@ final class ProgVC: UIViewController {
             // // 上記で算出した時間と現時刻の差分を取得する
             let remaining = calendar.dateComponents([.hour, .minute], from: today, to: endday!)
             
-            // TODO: 毎日の場合の計算
             return "残り\(remaining.hour!)時間\(remaining.minute!)分"
             
         case "毎週":
@@ -101,8 +102,6 @@ final class ProgVC: UIViewController {
             return "残り\(remaining.day!)日\(remaining.hour!)時間"
             
         case "毎月":
-            // UserDefaultsで保存してある曜日設定を取得
-            // 設定されていない場合の初期値は31日（月末）とする
             userDefaults.register(defaults: ["dayOfMonthToStart": 1])
             let dayOfMonthToStart = userDefaults.integer(forKey: "dayOfMonthToStart")
             // 取得した日付情報(Int)でDateComponentsを生成する
@@ -111,7 +110,7 @@ final class ProgVC: UIViewController {
             let deadline = calendar.nextDate(after: today, matching: components, matchingPolicy: .nextTime)
             // 上記で算出した日付と今日の日付の差分を取得する
             let remaining = calendar.dateComponents([.day, .hour], from: today, to: deadline!)
-            // TODO: 毎月の場合の計算
+            
             return "残り\(remaining.day!)日"
             
         default:
@@ -119,14 +118,9 @@ final class ProgVC: UIViewController {
             return "TODO: default"
         }
     }
-    
-    @IBOutlet weak var cycleLabel: UILabel!
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // UserDefaults のインスタンス
-        let userDefaults = UserDefaults.standard
-        // UserDefaultsに今保存した値を確認する
-        _ = userDefaults.string(forKey: "deadlineCycle") ?? "deadlineCycleは保存されていません"
 
         let result = calcRemainingPeriod()
         

--- a/Stepippo/Classes/Views/Prog.storyboard
+++ b/Stepippo/Classes/Views/Prog.storyboard
@@ -194,6 +194,9 @@
                     <navigationItem key="navigationItem" id="F8I-me-VVy">
                         <nil key="title"/>
                     </navigationItem>
+                    <connections>
+                        <outlet property="cycleLabel" destination="ZMm-BU-hLq" id="6Gl-vq-uXx"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lbT-nJ-4ed" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
fixes #176 

(#の後にcloseしたいissueの番号を記述してください)

### Summary(要約)

- UserDefaultsで現在日時を取得

- UserDefaultsで現在日時と残り期間の差分を算出

- 算出した残り期間をLabelに表示する

### Other Information(他の情報)

- Label表示が途切れているが、後に改行などで修正する

### Tested(テストしたこと)

- 現日時と残り期間の差分がLabelに表示されること

![Screen Shot 0001-06-16 at 9 06 53 PM](https://user-images.githubusercontent.com/45029154/59564320-4935ff80-9080-11e9-80c5-d52c49be5c89.png)
