### PR TITLE
StockedIPPOVCの課題を修正

### DIFF
--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		9173A4B222902180007749F0 /* IPPO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9173A4B122902180007749F0 /* IPPO.swift */; };
 		981A34DF22986BF000D21868 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981A34DE22986BF000D21868 /* Date+Extension.swift */; };
 		98505F8B229ED3FA00AE0891 /* XLPagerTabStrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67920DAF2262C2D100127083 /* XLPagerTabStrip.framework */; };
+		98A6462F22BE79E1008006AB /* UIScrollView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A6462E22BE79E1008006AB /* UIScrollView+Extension.swift */; };
 		E7D8326F2295939E00FA81DA /* AddTaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D8326D2295939E00FA81DA /* AddTaskCell.swift */; };
 		E7D832702295939E00FA81DA /* AddTaskCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E7D8326E2295939E00FA81DA /* AddTaskCell.xib */; };
 		E7E97F6A2285B04700920B74 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E97F692285B04700920B74 /* UIView+Extension.swift */; };
@@ -91,6 +92,7 @@
 		8DD50CF42289A33800098AA3 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		9173A4B122902180007749F0 /* IPPO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPPO.swift; sourceTree = "<group>"; };
 		981A34DE22986BF000D21868 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		98A6462E22BE79E1008006AB /* UIScrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extension.swift"; sourceTree = "<group>"; };
 		E7D8326D2295939E00FA81DA /* AddTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskCell.swift; sourceTree = "<group>"; };
 		E7D8326E2295939E00FA81DA /* AddTaskCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddTaskCell.xib; sourceTree = "<group>"; };
 		E7E97F692285B04700920B74 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				8DD50CF42289A33800098AA3 /* Int+Extension.swift */,
 				E7E97F692285B04700920B74 /* UIView+Extension.swift */,
 				981A34DE22986BF000D21868 /* Date+Extension.swift */,
+				98A6462E22BE79E1008006AB /* UIScrollView+Extension.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -343,6 +346,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D071CBD225A44FC004A4A69 /* MiscVC.swift in Sources */,
+				98A6462F22BE79E1008006AB /* UIScrollView+Extension.swift in Sources */,
 				6788A26E226A0ED000E9B0D5 /* ListedIPPOVC.swift in Sources */,
 				0B04AA7A227A9D5100E18F0A /* ProgVC.swift in Sources */,
 				8DD50CF52289A33800098AA3 /* Int+Extension.swift in Sources */,

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -4,12 +4,17 @@ import XLPagerTabStrip
 
 final class StockedIPPOVC: UIViewController, RealmObjectAccessible {
 
-    // TODO: リストのセクション分け
     private var stockedIppoList: Results<IPPO>?
+    @IBOutlet private weak var tableView: UITableView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         getStockedIppo()
+        tableView.reloadData()
     }
     
     private func getStockedIppo() {

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -56,7 +56,10 @@ extension StockedIPPOVC: UITableViewDelegate {
         let doneAction = UIContextualAction(style: .normal, title: "Done") { (_, _, completion) in
             guard let realm = try? Realm() else { print("Realmインスタンスの生成に失敗"); return }
             try? realm.write { [weak self] in
-                self?.stockedIppoList?[indexPath.row]._status = IPPOStatus.achieved.rawValue
+                if let ippo = self?.stockedIppoList?[indexPath.row] {
+                    ippo.status = .achieved
+                    ippo.performedDateTime = Date()
+                }
                 tableView.reloadData()
                 completion(true)
             }

--- a/Stepippo/Classes/Util/UIScrollView+Extension.swift
+++ b/Stepippo/Classes/Util/UIScrollView+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  UIScrollView+Extension.swift
+//  Stepippo
+//
+//  Created by tgaiacontentsdev on 2019/06/22.
+//  Copyright © 2019 Yasasii-kai. All rights reserved.
+//
+
+import UIKit
+
+// ListedIPPOVCのスワイプ競合対応
+extension UIScrollView {
+    open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        // TableViewのScrollが切れないようにする
+        guard type(of: self) == UIScrollView.self else { return view }
+        
+        if let v = view {
+            // UITableViewCellContentView型を直接扱えないため文字列にして比較
+            self.isScrollEnabled = String(describing:type(of: v)) != "UITableViewCellContentView"
+        }
+        return view
+    }
+}

--- a/Stepippo/Classes/Views/StockedIPPO.storyboard
+++ b/Stepippo/Classes/Views/StockedIPPO.storyboard
@@ -62,6 +62,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Mnn-Mo-lar"/>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="ftf-g2-0Ez" id="8B7-KI-wGG"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hkD-HO-ETW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
fixes #203 

### Summary(要約)
タスク一覧のストック画面でセルを左にスワイプした際にメニューが表示されず、達成済み画面に移動してしまう。
また、ストックされたIPPOをメニューからDoneしてもperformedDateTimeをセットしてなかったため達成済みに表示されない。

### Other Information(他の情報)
スワイプ操作の競合解消は、UIScrollViewをタップした時に、タッチ座標にUITableViewのセルがあったらUIScrollViewのスクロール動作をオフにする方法で対応しました。
Extensionで実装しているので、この画面以外で使うUIScrollViewにも影響します。
問題がありそうであればご指摘ください。

### Tested(テストしたこと)
シミュレーターで動作確認。

