### PR TITLE
RealmObjectAccessibleをIPPO専用にして、プライマリキーをStringに変更

### DIFF
--- a/Stepippo.xcodeproj/project.pbxproj
+++ b/Stepippo.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		8D8FB76C226B65A60063D8EC /* BugIssueVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FB76B226B65A60063D8EC /* BugIssueVC.swift */; };
 		8D8FB76F226B6F100063D8EC /* SubtitleAndIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8FB76D226B6F100063D8EC /* SubtitleAndIconCell.swift */; };
 		8D8FB770226B6F100063D8EC /* SubtitleAndIconCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D8FB76E226B6F100063D8EC /* SubtitleAndIconCell.xib */; };
-		8DD50CF02285E92A00098AA3 /* RealmObjectAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CEF2285E92A00098AA3 /* RealmObjectAccessible.swift */; };
+		8DD50CF02285E92A00098AA3 /* IPPORepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CEF2285E92A00098AA3 /* IPPORepository.swift */; };
 		8DD50CF52289A33800098AA3 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD50CF42289A33800098AA3 /* Int+Extension.swift */; };
 		9173A4B222902180007749F0 /* IPPO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9173A4B122902180007749F0 /* IPPO.swift */; };
 		981A34DF22986BF000D21868 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981A34DE22986BF000D21868 /* Date+Extension.swift */; };
@@ -88,7 +88,7 @@
 		8D8FB76B226B65A60063D8EC /* BugIssueVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugIssueVC.swift; sourceTree = "<group>"; };
 		8D8FB76D226B6F100063D8EC /* SubtitleAndIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleAndIconCell.swift; sourceTree = "<group>"; };
 		8D8FB76E226B6F100063D8EC /* SubtitleAndIconCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitleAndIconCell.xib; sourceTree = "<group>"; };
-		8DD50CEF2285E92A00098AA3 /* RealmObjectAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmObjectAccessible.swift; sourceTree = "<group>"; };
+		8DD50CEF2285E92A00098AA3 /* IPPORepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPPORepository.swift; sourceTree = "<group>"; };
 		8DD50CF42289A33800098AA3 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		9173A4B122902180007749F0 /* IPPO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPPO.swift; sourceTree = "<group>"; };
 		981A34DE22986BF000D21868 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
@@ -178,7 +178,7 @@
 			children = (
 				8D8FB763226B0AFD0063D8EC /* GitHubIssue.swift */,
 				8D8FB761226A1AA60063D8EC /* GitHubAPIClient.swift */,
-				8DD50CEF2285E92A00098AA3 /* RealmObjectAccessible.swift */,
+				8DD50CEF2285E92A00098AA3 /* IPPORepository.swift */,
 				9173A4B122902180007749F0 /* IPPO.swift */,
 			);
 			path = Models;
@@ -361,7 +361,7 @@
 				8D8FB76F226B6F100063D8EC /* SubtitleAndIconCell.swift in Sources */,
 				E7D8326F2295939E00FA81DA /* AddTaskCell.swift in Sources */,
 				9173A4B222902180007749F0 /* IPPO.swift in Sources */,
-				8DD50CF02285E92A00098AA3 /* RealmObjectAccessible.swift in Sources */,
+				8DD50CF02285E92A00098AA3 /* IPPORepository.swift in Sources */,
 				8D29221222460A790046917F /* AppDelegate.swift in Sources */,
 				8D0B3A0C22676AF900B71A7C /* GoalSettingVC.swift in Sources */,
 				0BF9DA91228464A70021096A /* CheckButton.swift in Sources */,

--- a/Stepippo/Classes/Controllers/AchievedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/AchievedIPPOVC.swift
@@ -10,7 +10,7 @@ import UIKit
 import RealmSwift
 import XLPagerTabStrip
 
-final class AchievedIPPOVC: UIViewController, RealmObjectAccessible {
+final class AchievedIPPOVC: UIViewController, IPPORepository {
 
     @IBOutlet private weak var tableView: UITableView!
     private var achievedIppoList: Results<IPPO>?
@@ -69,7 +69,7 @@ final class AchievedIPPOVC: UIViewController, RealmObjectAccessible {
     }
     
     private func getAchievedIppo() {
-        achievedIppoList = fetch(IPPO.self, predicate: NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.achieved.rawValue]))
+        achievedIppoList = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.achieved.rawValue]))
         
     }
     

--- a/Stepippo/Classes/Controllers/GoalSettingVC.swift
+++ b/Stepippo/Classes/Controllers/GoalSettingVC.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 /// タスクの目標を設定する画面
-final class GoalSettingVC: UIViewController, RealmObjectAccessible {
+final class GoalSettingVC: UIViewController, IPPORepository {
     var taskArray: [String] = []
 
     // MARK: - IBOutlet properties

--- a/Stepippo/Classes/Controllers/ProgVC.swift
+++ b/Stepippo/Classes/Controllers/ProgVC.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class ProgVC: UIViewController, RealmObjectAccessible {
+final class ProgVC: UIViewController, IPPORepository {
     
     @IBOutlet private weak var cycleLabel: UILabel!
     
@@ -124,9 +124,9 @@ final class ProgVC: UIViewController, RealmObjectAccessible {
     private func numberOfIPPO() -> String {
         //達成数を取得する
         //未達成の数
-    let numberOfChallengingIPPO = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray:[IPPOStatus.challenging.rawValue])).count
+    let numberOfChallengingIPPO = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray:[IPPOStatus.challenging.rawValue])).count
         //達成中の数
-    let numberOfPerformedIPPO = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray:[IPPOStatus.performed.rawValue])).count
+    let numberOfPerformedIPPO = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray:[IPPOStatus.performed.rawValue])).count
         //未達成と達成中の数を加算し、挑戦中の数を算出する
     let currentIPPO = numberOfPerformedIPPO + numberOfChallengingIPPO
         

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -2,7 +2,7 @@ import UIKit
 import RealmSwift
 import XLPagerTabStrip
 
-final class StockedIPPOVC: UIViewController, RealmObjectAccessible {
+final class StockedIPPOVC: UIViewController, IPPORepository {
 
     private var stockedIppoList: Results<IPPO>?
     @IBOutlet private weak var tableView: UITableView!
@@ -18,7 +18,7 @@ final class StockedIPPOVC: UIViewController, RealmObjectAccessible {
     }
     
     private func getStockedIppo() {
-        stockedIppoList = fetch(IPPO.self).filter(NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue])).sorted(byKeyPath: "addDateTime", ascending: false)
+        stockedIppoList = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]), sortKeyPath: "addDateTime", ascending: false)
     }
 }
 

--- a/Stepippo/Classes/Controllers/StockedIPPOVC.swift
+++ b/Stepippo/Classes/Controllers/StockedIPPOVC.swift
@@ -18,7 +18,7 @@ final class StockedIPPOVC: UIViewController, IPPORepository {
     }
     
     private func getStockedIppo() {
-        stockedIppoList = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]), sortKeyPath: "addDateTime", ascending: false)
+        stockedIppoList = fetch(predicate: NSPredicate(format: "_status = %@", argumentArray: [IPPOStatus.stock.rawValue]), sortKeyPath: "addDateTime", isAcsending: false)
     }
 }
 

--- a/Stepippo/Classes/Models/IPPORepository.swift
+++ b/Stepippo/Classes/Models/IPPORepository.swift
@@ -1,5 +1,5 @@
 //
-//  RealmObjectAccessible.swift
+//  IPPORepository.swift
 //  Stepippo
 //
 //  Created by 村松龍之介 on 2019/05/11.
@@ -10,10 +10,10 @@ import Foundation
 import RealmSwift
 
 /// Realmオブジェクトを操作するためのプロトコル
-protocol RealmObjectAccessible {}
+protocol IPPORepository {}
 
 // MARK: - RealmObjectAccessor Extension
-extension RealmObjectAccessible {
+extension IPPORepository {
     
     // MARK: - 書き込み
     
@@ -22,12 +22,12 @@ extension RealmObjectAccessible {
     /// - Parameters:
     ///   - object: 追加するRealmオブジェクト
     ///   - isUpdate: すでに存在するプライマリーキーを指定していた場合に更新するか否か
-    func write<T: Object>(_ object: T, isUpdate: Bool = true) {
+    func write(_ ippo: IPPO, isUpdate: Bool = true) {
         
         let realm = try! Realm()
         
         try! realm.write {
-            realm.add(object, update: isUpdate)
+            realm.add(ippo, update: isUpdate)
         }
     }
     
@@ -37,7 +37,7 @@ extension RealmObjectAccessible {
     ///   - primaryKey: 一意のID
     ///   - values: 更新したいサブセット
     ///   - isUpdate: すでにあるプライマリーキーだった場合、更新するか否か。デフォルトは更新する
-    func update(with primaryKey: Int, values: [String: Any], isUpdate: Bool = true) {
+    func update(with primaryKey: String, values: [String: Any], isUpdate: Bool = true) {
         
         let realm = try! Realm()
         
@@ -56,14 +56,14 @@ extension RealmObjectAccessible {
     ///   - objectType: Realmオブジェクトの型
     ///   - predicate: 検索条件
     /// - Returns: 検索結果のRealmオブジェクト
-    func fetch<T: Object>(_ objectType: T.Type, predicate: NSPredicate? = nil) -> Results<T> {
+    func fetch(predicate: NSPredicate? = nil) -> Results<IPPO> {
         
         let realm = try! Realm()
 
         if let predicate = predicate {
-            return realm.objects(objectType).filter(predicate)
+            return realm.objects(IPPO.self).filter(predicate)
         }
-        return realm.objects(objectType)
+        return realm.objects(IPPO.self)
     }
     
     /// フィルタリング検索し、並び替えをしたRealmオブジェクト結果を返す
@@ -74,15 +74,15 @@ extension RealmObjectAccessible {
     ///   - sortKeyPath: 並び替えに使うkey
     ///   - isAcsending: 昇順か否か。デフォルトは昇順
     /// - Returns: 検索結果のRealmオブジェクト
-    func fetch<T: Object>(_ objectType: T.Type, predicate: NSPredicate?, sortKeyPath: String, isAcsending: Bool = true) -> Results<T> {
+    func fetch(predicate: NSPredicate?, sortKeyPath: String, isAcsending: Bool = true) -> Results<IPPO> {
         // predicateが指定されていればけフィルタリングを行う
         if let predicate = predicate {
-            return fetch(objectType, predicate: predicate).sorted(byKeyPath: sortKeyPath, ascending: isAcsending)
+            return fetch(predicate: predicate).sorted(byKeyPath: sortKeyPath, ascending: isAcsending)
         }
         
         let realm = try! Realm()
 
-        return realm.objects(objectType).sorted(byKeyPath: sortKeyPath, ascending: isAcsending)
+        return realm.objects(IPPO.self).sorted(byKeyPath: sortKeyPath, ascending: isAcsending)
     }
     
     // MARK: - 削除
@@ -90,12 +90,11 @@ extension RealmObjectAccessible {
     /// 渡されたRealmオブジェクトを削除する
     ///
     /// - Parameter object: Realm Model Object
-    func delete<T: Object>(object: T) {
+    func delete(ippo: IPPO) {
         
         let realm = try! Realm()
-        
         try! realm.write {
-            realm.delete(object)
+            realm.delete(ippo)
         }
     }
     
@@ -103,28 +102,8 @@ extension RealmObjectAccessible {
     func deleteAll() {
         
         let realm = try! Realm()
-        
         try! realm.write {
             realm.deleteAll()
-        }
-    }
-    
-    // MARK: - Primary key
-    
-    /// Realmオブジェクトで使う、インクリメントしたプライマリーキーを返す
-    ///
-    /// - Parameter object: 対象のRealmオブジェクト
-    /// - Returns: インクリメントしたプライマリーキー
-    func createIncrementedPrimaryKey<T: Object>(objectType: T.Type) -> Int {
-        guard let key = T.primaryKey() else { fatalError("このオブジェクトにはプライマリキーがありません") }
-        
-        let firstId = 0
-        // 最後のプライマリーキーを取得
-        if let last = fetch(objectType, predicate: nil, sortKeyPath: "id").last,
-            let lastId = last[key] as? Int {
-            return lastId.incremented
-        } else {
-            return firstId
         }
     }
 }


### PR DESCRIPTION
fixes #163 

(#の後にcloseしたいissueの番号を記述してください)

### Summary(要約)
RealmObjectAccessibleをIPPO専用のものとし、わかりやすく名前も変更しました。
プライマリキーをString型に変更し、プライマリキーをインクリメントするメソッドも削除しました。

### Other Information(他の情報)
おそらく今現在使っている個所の修正もできたと思うのですが、
諸事情により、現在ビルドできなくて動作確認できていません💦

エラーなど出ていないか動作確認していただけないでしょうか？